### PR TITLE
Disabled the CMS sideframe

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -189,6 +189,8 @@ CMS_PERMISSION = True
 
 CMS_PLACEHOLDER_CONF = {}
 
+CMS_SIDEFRAME_ENABLED = False  # Disable the CMS sidefrane
+
 DATABASES = {
     'default': {
         'CONN_MAX_AGE': 0,


### PR DESCRIPTION
The sideframe is currently disabled on our staging environment, this setting allows us to reflect the current state of the staging site.